### PR TITLE
docs: add REQUIREMENTS.md and link as authoritative spec source

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -381,3 +381,58 @@ expect(component.state.isLoading).toBe(true)
 | Never commit `.env` or `.env.local` files | Contains secrets; `.env.example` is the committed reference |
 | Never disable TypeScript strict checks with `@ts-ignore` without a comment | If suppression is truly needed, use `@ts-expect-error` with an explanation |
 | Never put more than one major concern in a component | Keep components small and single-responsibility |
+
+---
+
+## Authoritative Requirements Source
+
+The file `REQUIREMENTS.md` is the canonical source of structured requirement rules and design document generation standards.
+
+Before performing any of the following tasks, you MUST:
+
+* Read `REQUIREMENTS.md` in full
+* Treat it as binding specification
+* Follow all generation rules defined in that file
+* Do not contradict or bypass its constraints
+
+This applies to:
+
+* GitHub issue → design document generation
+* Architecture generation
+* Security design output
+* Workflow design
+* CI/CD automation
+* Prompt distribution features
+* Policy design
+
+If `REQUIREMENTS.md` conflicts with any other instruction in this repository, `REQUIREMENTS.md` takes precedence unless explicitly overridden in writing in this file.
+
+---
+
+## Mandatory Pre-Execution Rule
+
+Before generating structured design documentation:
+
+1. Load `REQUIREMENTS.md`
+2. Identify required output structure
+3. Apply all strict generation rules
+4. Apply security baseline controls
+5. Produce a complete document
+
+Do not skip this step.
+
+---
+
+## File Hierarchy and Precedence
+
+Order of authority:
+
+1. REQUIREMENTS.md (generation rules + design template)
+2. SECURITY.md (security constraints and policies)
+3. ARCHITECTURE.md (system structure and conventions)
+4. CLAUDE.md (behavioral execution instructions)
+
+If ambiguity exists:
+
+* Security constraints override architectural convenience.
+* Requirements override stylistic preferences.

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,0 +1,250 @@
+# REQUIREMENTS.md — oMapArchive
+
+## Purpose
+
+This repository follows a **requirements-driven engineering model**.
+
+All non-trivial changes — including features, workflows, automations, security controls, and architectural changes — must originate from a structured requirement defined in this document format.
+
+No design, architecture, or security implementation may be generated without a corresponding structured requirement.
+
+---
+
+## Operating Model
+
+All requirements must:
+
+1. Be deterministic and testable
+2. Define scope boundaries explicitly
+3. Include architectural impact
+4. Include a minimal threat model
+5. Define measurable success metrics
+6. Define testing strategy
+7. Avoid speculative features
+8. Avoid implementation ambiguity
+
+If information is missing:
+
+* Explicit assumptions must be documented
+* Risk of incorrect assumption must be stated
+
+---
+
+## Requirement Lifecycle
+
+1. GitHub issue created
+2. Requirement generated using template below
+3. Architecture and security design derived from requirement
+4. Implementation follows approved design
+5. Tests validate requirement success criteria
+
+No implementation should precede structured requirement approval.
+
+---
+
+# Requirement Template
+
+Copy the following section for each new requirement.
+
+---
+
+# Requirement: <Short Descriptive Title>
+
+**Date:** <YYYY-MM-DD>
+**Status:** Draft | In Review | Approved | Rejected
+**Owner:** <Role or Team>
+**Related Issue:** #<number>
+
+---
+
+## 1. Overview
+
+**Purpose** <What problem is being solved and why it matters.>
+
+**Business or Operational Impact** <Describe measurable impact or risk reduction.>
+
+---
+
+## 2. Scope
+
+**In Scope**
+
+* <Capability 1>
+* <Capability 2>
+* <Capability 3>
+
+**Out of Scope**
+
+* <Explicit non-goal 1>
+* <Explicit non-goal 2>
+
+---
+
+## 3. User Story
+
+**As a** <persona>
+**I want** <capability>
+**So that** <measurable outcome>
+
+---
+
+## 4. Acceptance Criteria
+
+All criteria must be testable.
+
+* [ ] <Behavior 1>
+* [ ] <Behavior 2>
+* [ ] <Behavior 3>
+
+---
+
+## 5. Assumptions
+
+If applicable:
+
+Assumption: <statement>
+Risk: <impact if incorrect>
+
+---
+
+## 6. Architecture Impact
+
+**Repositories Affected**
+
+* <Repo A>
+* <Repo B>
+
+**Workflows Affected**
+
+* <Workflow name>
+
+**Configuration Changes**
+
+* <New config required?>
+* <Schema changes?>
+
+**Data Flow Impact**
+
+* <Describe new or changed flow>
+
+---
+
+## 7. Security Considerations
+
+Minimum required:
+
+### Assets
+
+* <Asset 1>
+* <Asset 2>
+
+### Threats
+
+* <Threat 1>
+* <Threat 2>
+
+### Controls
+
+* Least privilege permissions
+* Input validation
+* Path normalization
+* SHA-pinned dependencies
+* Audit logging
+
+If cross-repository access is involved:
+
+* Token scope must be minimal
+* Repository allowlist required
+* Rotation policy defined
+
+---
+
+## 8. Failure Handling
+
+* Define expected failure states
+* Define retry behavior
+* Define isolation boundaries
+* Define logging requirements
+
+---
+
+## 9. Observability
+
+* Logs required
+* Metrics required
+* Alerting requirements
+* Audit traceability expectations
+
+---
+
+## 10. Testing Requirements
+
+Must include:
+
+**Unit Tests**
+
+* <Validation tests>
+
+**Integration Tests**
+
+* <Workflow tests>
+
+**End-to-End Tests**
+
+* <Full pipeline validation>
+
+**Negative Tests**
+
+* <Permission boundary tests>
+* <Malformed config tests>
+
+---
+
+## 11. Success Metrics
+
+Must be measurable.
+
+* Success rate target: <percentage>
+* Latency target: <time>
+* Error rate threshold: <percentage>
+* Adoption or usage metric: <definition>
+
+---
+
+## 12. Alternatives Considered
+
+| Alternative       | Pros | Cons | Decision |
+| ----------------- | ---- | ---- | -------- |
+| Option A          |      |      |          |
+| Option B          |      |      |          |
+| Selected Approach |      |      |          |
+
+Provide rationale.
+
+---
+
+## 13. Rollout Plan
+
+* Phase 1: <Internal validation>
+* Phase 2: <Limited exposure>
+* Phase 3: <Full deployment>
+
+Define rollback conditions.
+
+---
+
+## 14. Future Enhancements (Optional)
+
+* <Enhancement 1>
+* <Enhancement 2>
+
+---
+
+# Enforcement Rules
+
+* Requirements must be complete before design begins.
+* All fields above are mandatory unless explicitly marked optional.
+* Security section may not be omitted.
+* Acceptance criteria must be testable.
+* Ambiguous requirements must document assumptions and risk.
+* Requirements override stylistic preferences in other documents.


### PR DESCRIPTION
## Summary

- Introduces `REQUIREMENTS.md` as the canonical requirements-driven engineering template, covering requirement lifecycle, structured sections (scope, user story, acceptance criteria, architecture impact, threat model, testing, success metrics, etc.), and enforcement rules
- Updates `CLAUDE.md` to declare `REQUIREMENTS.md` as the top-level authority for design document generation, with a defined file hierarchy and mandatory pre-execution steps

## Test plan

- [ ] Verify `REQUIREMENTS.md` renders correctly on GitHub
- [ ] Verify `CLAUDE.md` changes are coherent and reference `REQUIREMENTS.md` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)