### PR TITLE
feat(ui): add public homepage at /

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+export const metadata: Metadata = { title: 'oMapArchive' }
+
+const HomePage = () => {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center px-4 text-center">
+      <div className="space-y-6 max-w-lg">
+        <div className="space-y-3">
+          <h1 className="text-5xl font-bold tracking-tight">oMapArchive</h1>
+          <p className="text-lg text-muted-foreground">
+            Archive, georeference, and relive your orienteering maps.
+          </p>
+        </div>
+
+        <Link
+          href="/login"
+          className="inline-block rounded-md bg-primary px-8 py-3 text-sm font-medium text-primary-foreground shadow-sm hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-ring transition-opacity"
+        >
+          Sign in
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+export default HomePage


### PR DESCRIPTION
Resolves #7

## Summary

- Adds `src/app/page.tsx` — a public landing page at `/` with the oMapArchive title banner, a short tagline, and a **Sign in** button linking to `/login`
- No middleware changes needed — `/` is already outside the protected `/(app)/:path*` matcher

## Test plan

- [ ] Navigate to `http://localhost:3000` — homepage renders (no 404)
- [ ] Click **Sign in** — navigates to `/login`
- [ ] `pnpm typecheck`, `pnpm lint`, `pnpm test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)