### PR TITLE
fix(maps): fix scale field inline layout and equidistance step

### DIFF
--- a/src/components/maps/UploadMapForm.tsx
+++ b/src/components/maps/UploadMapForm.tsx
@@ -38,7 +38,7 @@ export const UploadMapForm = () => {
             Scale <span className="text-destructive">*</span>
           </label>
           <div className="flex items-center gap-1.5">
-            <span className="text-sm text-muted-foreground">1 :</span>
+            <span className="shrink-0 text-sm text-muted-foreground">1 :</span>
             <input
               id="scale"
               name="scale"
@@ -46,7 +46,7 @@ export const UploadMapForm = () => {
               min="1"
               required
               disabled={isPending}
-              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+              className="min-w-0 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
               placeholder="10000"
             />
           </div>
@@ -61,7 +61,7 @@ export const UploadMapForm = () => {
             name="equidistance"
             type="number"
             min="0.1"
-            step="0.5"
+            step="0.1"
             disabled={isPending}
             className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
             placeholder="5"


### PR DESCRIPTION
Resolves #12

## Summary

- **Scale field**: adds `shrink-0` to the `1 :` prefix span and `min-w-0` to the input so all three elements stay on one horizontal line inside the narrow grid column
- **Equidistance field**: changes `step` from `0.5` to `0.1`, allowing any one-decimal-place value

🤖 Generated with [Claude Code](https://claude.com/claude-code)