### PR TITLE
fix(maps): raise server action body limit to 15 MB and tighten equidistance

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,11 @@ const securityHeaders = [
 ]
 
 const nextConfig: NextConfig = {
+  experimental: {
+    serverActions: {
+      bodySizeLimit: '15mb',
+    },
+  },
   async headers() {
     return [{ source: '/:path*', headers: securityHeaders }]
   },

--- a/src/components/maps/UploadMapForm.tsx
+++ b/src/components/maps/UploadMapForm.tsx
@@ -60,8 +60,9 @@ export const UploadMapForm = () => {
             id="equidistance"
             name="equidistance"
             type="number"
-            min="0.1"
-            step="0.1"
+            min="1.0"
+            max="1000.0"
+            step="0.5"
             disabled={isPending}
             className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
             placeholder="5"

--- a/src/server/maps/actions.ts
+++ b/src/server/maps/actions.ts
@@ -28,7 +28,12 @@ const uploadSchema = z.object({
     .positive('Scale must be positive'),
   equidistance: z.preprocess(
     (v) => (v === '' ? undefined : v),
-    z.coerce.number().positive('Equidistance must be positive').optional(),
+    z.coerce
+      .number()
+      .min(1, 'Equidistance must be at least 1 m')
+      .max(1000, 'Equidistance must be at most 1000 m')
+      .multipleOf(0.5, 'Equidistance must be a multiple of 0.5')
+      .optional(),
   ),
   yearUpdated: z.preprocess(
     (v) => (v === '' ? undefined : v),


### PR DESCRIPTION
## Summary

**Body size limit**
- Adds `experimental.serverActions.bodySizeLimit: '15mb'` to `next.config.ts`, raising the default 1 MB cap so map files up to 15 MB can be uploaded

**Equidistance field**
- Input: `min="1.0"`, `max="1000.0"`, `step="0.5"` — only `.0` and `.5` values accepted by the browser
- Zod validation mirrors the constraints: `min(1)`, `max(1000)`, `multipleOf(0.5)`

## Test plan

- [ ] Upload a file larger than 1 MB — no longer returns body size error
- [ ] Equidistance accepts `1.0`, `1.5`, `2.0`, `999.5`, `1000.0`
- [ ] Equidistance rejects `0.5`, `1000.5`, `1.1` (browser-level and server-level)
- [ ] `pnpm typecheck` and `pnpm lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)