### PR TITLE
feat(maps): add map deletion with ownership check

### DIFF
--- a/src/components/maps/DeleteMapButton.tsx
+++ b/src/components/maps/DeleteMapButton.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { deleteMapAction } from '@/server/maps/actions'
+
+type Props = {
+  mapId: string
+}
+
+export const DeleteMapButton = ({ mapId }: Props) => {
+  const [confirming, setConfirming] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  const handleDelete = () => {
+    startTransition(async () => {
+      try {
+        await deleteMapAction(mapId)
+      } catch {
+        setError('Failed to delete map. Please try again.')
+        setConfirming(false)
+      }
+    })
+  }
+
+  if (error) {
+    return <p className="text-xs text-destructive">{error}</p>
+  }
+
+  if (confirming) {
+    return (
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-muted-foreground">Delete map?</span>
+        <button
+          onClick={handleDelete}
+          disabled={isPending}
+          className="text-xs font-medium text-destructive hover:underline disabled:opacity-50"
+        >
+          {isPending ? 'Deleting…' : 'Confirm'}
+        </button>
+        <button
+          onClick={() => setConfirming(false)}
+          disabled={isPending}
+          className="text-xs text-muted-foreground hover:text-foreground disabled:opacity-50"
+        >
+          Cancel
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <button
+      onClick={() => setConfirming(true)}
+      className="text-xs text-muted-foreground hover:text-destructive transition-colors"
+    >
+      Delete
+    </button>
+  )
+}

--- a/src/components/maps/MapCard.tsx
+++ b/src/components/maps/MapCard.tsx
@@ -1,4 +1,5 @@
 import type { Map } from '@/server/db/schema'
+import { DeleteMapButton } from './DeleteMapButton'
 import { MapFormatBadge } from './MapFormatBadge'
 import { MapStatusBadge } from './MapStatusBadge'
 
@@ -30,7 +31,10 @@ export const MapCard = ({ map }: MapCardProps) => {
         <MapStatusBadge status={map.processingStatus} />
       </div>
 
-      <p className="text-xs text-muted-foreground">Uploaded {uploadDate}</p>
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-muted-foreground">Uploaded {uploadDate}</p>
+        <DeleteMapButton mapId={map.id} />
+      </div>
     </div>
   )
 }

--- a/src/lib/storage/blob-client.ts
+++ b/src/lib/storage/blob-client.ts
@@ -34,3 +34,28 @@ export const uploadOriginal = async (
   await fs.writeFile(path.join(dir, filename), data)
   return `local:originals/${userId}/${mapId}/${filename}`
 }
+
+/**
+ * Deletes a map file from the originals store.
+ * Errors are swallowed — a missing file should not block DB record deletion.
+ */
+export const deleteOriginal = async (fileUrl: string): Promise<void> => {
+  if (fileUrl.startsWith('local:')) {
+    const relativePath = fileUrl.slice('local:'.length)
+    const fullPath = path.join(process.cwd(), '.local-storage', relativePath)
+    await fs.unlink(fullPath).catch(() => undefined)
+    return
+  }
+
+  if (env.AZURE_STORAGE_ACCOUNT_NAME && env.AZURE_STORAGE_SAS_TOKEN) {
+    const { BlobServiceClient } = await import('@azure/storage-blob')
+    const blobServiceClient = new BlobServiceClient(
+      `https://${env.AZURE_STORAGE_ACCOUNT_NAME}.blob.core.windows.net?${env.AZURE_STORAGE_SAS_TOKEN}`,
+    )
+    const containerClient = blobServiceClient.getContainerClient('originals')
+    const blobName = new URL(fileUrl).pathname.split('/originals/')[1]
+    if (blobName) {
+      await containerClient.deleteBlob(blobName).catch(() => undefined)
+    }
+  }
+}

--- a/src/server/maps/actions.ts
+++ b/src/server/maps/actions.ts
@@ -1,11 +1,13 @@
 'use server'
 
+import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
+import { eq } from 'drizzle-orm'
 import { z } from 'zod'
 import { auth } from '@/server/auth'
 import { db } from '@/server/db'
 import { maps, originalFormatEnum } from '@/server/db/schema'
-import { uploadOriginal } from '@/lib/storage/blob-client'
+import { deleteOriginal, uploadOriginal } from '@/lib/storage/blob-client'
 
 type OriginalFormat = (typeof originalFormatEnum.enumValues)[number]
 
@@ -107,4 +109,25 @@ export const uploadMapAction = async (
   })
 
   redirect('/maps')
+}
+
+export const deleteMapAction = async (mapId: string): Promise<void> => {
+  const session = await auth()
+  if (!session?.user?.id) throw new Error('Not authenticated')
+
+  const map = await db
+    .select()
+    .from(maps)
+    .where(eq(maps.id, mapId))
+    .then((r) => r[0] ?? null)
+
+  if (!map) throw new Error('Map not found')
+  if (map.userId !== session.user.id) throw new Error('Forbidden')
+
+  // Best-effort file deletion — don't let a missing file block the DB delete
+  await deleteOriginal(map.originalFileUrl)
+
+  await db.delete(maps).where(eq(maps.id, mapId))
+
+  revalidatePath('/maps')
 }


### PR DESCRIPTION
Resolves #16

## Summary

- **Storage**: `deleteOriginal` in `blob-client.ts` deletes the file from Azure Blob Storage or the local filesystem fallback; errors are swallowed so a missing file never blocks the DB delete
- **Server action**: `deleteMapAction` verifies the session, checks ownership (IDOR protection), deletes the file, removes the `maps` row (cascades to `map_georeferences`), and revalidates `/maps`
- **UI**: `DeleteMapButton` client component on each `MapCard` — shows an inline "Delete map? Confirm / Cancel" prompt before calling the action

## Test plan

- [ ] Click **Delete** on a map card → confirm prompt appears
- [ ] Click **Cancel** → prompt dismisses, map remains
- [ ] Click **Confirm** → card disappears, maps list refreshes
- [ ] File removed from `.local-storage/originals/`
- [ ] Attempting to delete another user's map returns a Forbidden error

🤖 Generated with [Claude Code](https://claude.com/claude-code)