### PR TITLE
feat(processing): add BullMQ map processing pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,6 @@ NODE_ENV=development
 # Azure Blob Storage — leave unset to use local filesystem fallback in development
 # AZURE_STORAGE_ACCOUNT_NAME=your-storage-account
 # AZURE_STORAGE_SAS_TOKEN=your-sas-token
+
+# Redis — leave as default for local development
+REDIS_URL=redis://localhost:6379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  db:
+    image: postgis/postgis:16-3.4-alpine
+    container_name: omaparchive-db
+    environment:
+      POSTGRES_DB: omaparchive
+      POSTGRES_USER: omaparchive
+      POSTGRES_PASSWORD: localdev
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U omaparchive"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:7-alpine
+    container_name: omaparchive-redis
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - redis-data:/data
+
+volumes:
+  db-data:
+  redis-data:

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,7 @@ const securityHeaders = [
 ]
 
 const nextConfig: NextConfig = {
+  serverExternalPackages: ['sharp', 'pdf2pic', 'ioredis', 'bullmq', 'geotiff', 'ocad2geojson'],
   experimental: {
     serverActions: {
       bodySizeLimit: '15mb',

--- a/package.json
+++ b/package.json
@@ -24,13 +24,19 @@
   "dependencies": {
     "@azure/storage-blob": "^12.31.0",
     "bcryptjs": "^3.0.3",
+    "bullmq": "^5.70.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.38.3",
+    "geotiff": "^3.0.4",
+    "ioredis": "^5.10.0",
     "next": "^15.5.12",
     "next-auth": "5.0.0-beta.30",
+    "ocad2geojson": "^2.1.20",
+    "pdf2pic": "^3.2.0",
     "pg": "^8.13.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "sharp": "^0.34.5",
     "tailwind-merge": "^3.5.0",
     "zod": "^3.24.2"
   },
@@ -40,6 +46,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@types/bcryptjs": "^3.0.0",
+    "@types/geojson": "^7946.0.16",
     "@types/node": "^22.13.9",
     "@types/pg": "^8.11.11",
     "@types/react": "^19.2.14",
@@ -57,7 +64,8 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "esbuild"
+      "esbuild",
+      "sharp"
     ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,18 +14,33 @@ importers:
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
+      bullmq:
+        specifier: ^5.70.1
+        version: 5.70.1
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
       drizzle-orm:
         specifier: ^0.38.3
         version: 0.38.4(@types/pg@8.18.0)(@types/react@19.2.14)(pg@8.19.0)(react@19.2.4)
+      geotiff:
+        specifier: ^3.0.4
+        version: 3.0.4
+      ioredis:
+        specifier: ^5.10.0
+        version: 5.10.0
       next:
         specifier: ^15.5.12
         version: 15.5.12(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-auth:
         specifier: 5.0.0-beta.30
         version: 5.0.0-beta.30(next@15.5.12(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      ocad2geojson:
+        specifier: ^2.1.20
+        version: 2.1.20
+      pdf2pic:
+        specifier: ^3.2.0
+        version: 3.2.0
       pg:
         specifier: ^8.13.3
         version: 8.19.0
@@ -35,6 +50,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -57,6 +75,9 @@ importers:
       '@types/bcryptjs':
         specifier: ^3.0.0
         version: 3.0.0
+      '@types/geojson':
+        specifier: ^7946.0.16
+        version: 7946.0.16
       '@types/node':
         specifier: ^22.13.9
         version: 22.19.13
@@ -972,6 +993,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@ioredis/commands@1.5.0':
+    resolution: {integrity: sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==}
+
+  '@ioredis/commands@1.5.1':
+    resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -987,6 +1014,42 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mapbox/point-geometry@0.1.0':
+    resolution: {integrity: sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==}
+
+  '@mapbox/vector-tile@1.3.1':
+    resolution: {integrity: sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==}
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -1335,6 +1398,18 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@turf/helpers@7.3.4':
+    resolution: {integrity: sha512-U/S5qyqgx3WTvg4twaH0WxF3EixoTCfDsmk98g1E3/5e2YKp7JKYZdz0vivsS5/UZLJeZDEElOSFH4pUgp+l7g==}
+
+  '@turf/invariant@7.3.4':
+    resolution: {integrity: sha512-88Eo4va4rce9sNZs6XiMJowWkikM3cS2TBhaCKlU+GFHdNf8PFEpiU42VDU8q5tOF6/fu21Rvlke5odgOGW4AQ==}
+
+  '@turf/line-offset@7.3.4':
+    resolution: {integrity: sha512-CSrg3njde9Tx+C0oL+BHUpZYpgD+PEmzp0ldDNis5ZQiTe5tUrwiIyG7A/QXf9eDnGhtV1WhCAycX0Wjged4pg==}
+
+  '@turf/meta@7.3.4':
+    resolution: {integrity: sha512-tlmw9/Hs1p2n0uoHVm1w3ugw1I6L8jv9YZrcdQa4SH5FX5UY0ATrKeIvfA55FlL//PGuYppJp+eyg/0eb4goqw==}
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -1365,6 +1440,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -1587,6 +1665,10 @@ packages:
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
+  JSONStream@1.3.5:
+    resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
+    hasBin: true
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1626,6 +1708,10 @@ packages:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
 
+  arr-flatten@1.1.0:
+    resolution: {integrity: sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==}
+    engines: {node: '>=0.10.0'}
+
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
@@ -1633,6 +1719,12 @@ packages:
   array-includes@3.1.9:
     resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
     engines: {node: '>= 0.4'}
+
+  array-parallel@0.1.3:
+    resolution: {integrity: sha512-TDPTwSWW5E4oiFiKmz6RGJ/a80Y91GuLgUYuLd49+XBS75tYo8PNgaT2K/OxuQYqkoI852MDGBorg9OcUSTQ8w==}
+
+  array-series@0.1.5:
+    resolution: {integrity: sha512-L0XlBwfx9QetHOsbLDrE/vh2t018w9462HM3iaFfxRiK83aJjAt/Ja3NMkOW7FICwWTlQBa3ZbL5FKhuQWkDrg==}
 
   array.prototype.findlast@1.2.5:
     resolution: {integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==}
@@ -1697,6 +1789,9 @@ packages:
     resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
     hasBin: true
 
+  bezier-js@2.6.1:
+    resolution: {integrity: sha512-jelZM33eNzcZ9snJ/5HqJLw3IzXvA8RFcBjkdOB8SDYyOvW8Y2tTosojAiBTnD1MhbHoWUYNbxUXxBl61TxbRg==}
+
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
@@ -1718,6 +1813,9 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  bullmq@5.70.1:
+    resolution: {integrity: sha512-HjfGHfICkAClrFL0Y07qNbWcmiOCv1l+nusupXUjrvTPuDEyPEJ23MP0lUwUs/QEy1a3pWt/P/sCsSZ1RjRK+w==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -1753,6 +1851,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1760,11 +1862,23 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  commander@6.2.1:
+    resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
+    engines: {node: '>= 6'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  concat-stream@2.0.0:
+    resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
+    engines: {'0': node >= 6.0}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cron-parser@4.9.0:
+    resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
+    engines: {node: '>=12.0.0'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1830,6 +1944,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -1949,6 +2067,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  duplexer@0.1.2:
+    resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
   electron-to-chromium@1.5.302:
     resolution: {integrity: sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==}
@@ -2154,6 +2275,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  event-stream@4.0.1:
+    resolution: {integrity: sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==}
+
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
@@ -2217,6 +2341,9 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  from@0.1.7:
+    resolution: {integrity: sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2244,6 +2371,16 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  geojson-stream@0.1.0:
+    resolution: {integrity: sha512-svSg5fFXPaTiqzEBGXScA+nISaeC9rLvku2PH+wM5LToATUw2bLIrvls43ymnT9Xnp51nBPVyK9m4Af40KpJ7w==}
+
+  geojson-vt@3.2.1:
+    resolution: {integrity: sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==}
+
+  geotiff@3.0.4:
+    resolution: {integrity: sha512-lzcQkSZ5XYAYgDVVCKrPPn6OyzFFEmewYc4PzQyzrKdf7KxCG5WPCnwvpkKNrz1nHQD1HkyYXo7ZRFAmlMrTOw==}
+    engines: {node: '>=10.19'}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -2275,6 +2412,11 @@ packages:
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
+
+  gm@1.25.1:
+    resolution: {integrity: sha512-jgcs2vKir9hFogGhXIfs0ODhJTfIrbECCehg38tqFgHm8zqXx7kAJyCYAFK4jTjx71AxrkFtkJBawbAxYUPX9A==}
+    engines: {node: '>=14'}
+    deprecated: The gm module has been sunset. Please migrate to an alternative. https://github.com/aheckmann/gm?tab=readme-ov-file#2025-02-24-this-project-is-not-maintained
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -2322,6 +2464,9 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -2338,9 +2483,20 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  ioredis@5.10.0:
+    resolution: {integrity: sha512-HVBe9OFuqs+Z6n64q09PQvP1/R4Bm+30PAyyD4wIEqssh3v9L21QjCVk4kRLucMBcDokJTcLjsGeVRlq/nH6DA==}
+    engines: {node: '>=12.22.0'}
+
+  ioredis@5.9.3:
+    resolution: {integrity: sha512-VI5tMCdeoxZWU5vjHWsiE/Su76JGhBvWF1MJnV9ZtGltHk9BmD48oDq8Tj8haZ85aceXZMxLNDQZRVo5QKNgXA==}
+    engines: {node: '>=12.22.0'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -2508,6 +2664,10 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonparse@1.3.1:
+    resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
+    engines: {'0': node >= 0.2.0}
+
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
@@ -2521,6 +2681,9 @@ packages:
   language-tags@1.0.9:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
+
+  lerc@3.0.0:
+    resolution: {integrity: sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -2604,6 +2767,12 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -2618,12 +2787,19 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  map-stream@0.0.7:
+    resolution: {integrity: sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2635,6 +2811,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  mgrs@1.0.0:
+    resolution: {integrity: sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -2650,8 +2829,20 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  msgpackr-extract@3.0.3:
+    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+    hasBin: true
+
+  msgpackr@1.11.5:
+    resolution: {integrity: sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -2703,9 +2894,16 @@ packages:
       sass:
         optional: true
 
+  node-abort-controller@3.1.1:
+    resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
+
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
+
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -2748,6 +2946,10 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  ocad2geojson@2.1.20:
+    resolution: {integrity: sha512-hP6/SLB4FBuSKBGPslmkS8Ij437k4l757ieLyQZx+jIQ55rbvnqSP29JtX1sJM3ihvYImf71tJBBlE9bdFwsUQ==}
+    hasBin: true
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -2764,9 +2966,15 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  pako@2.1.0:
+    resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-headers@2.0.6:
+    resolution: {integrity: sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==}
 
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
@@ -2784,6 +2992,17 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pause-stream@0.0.11:
+    resolution: {integrity: sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==}
+
+  pbf@3.3.0:
+    resolution: {integrity: sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==}
+    hasBin: true
+
+  pdf2pic@3.2.0:
+    resolution: {integrity: sha512-p0bp+Mp4iJy2hqSCLvJ521rDaZkzBvDFT9O9Y0BUID3I04/eDaebAFM5t8hoWeo2BCf42cDijLCGJWTOtkJVpA==}
+    engines: {node: '>=14'}
 
   pg-cloudflare@1.3.0:
     resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
@@ -2874,8 +3093,14 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  proj4@2.20.3:
+    resolution: {integrity: sha512-uKJXnf/RkHhExxnWHqQqy2J1bPc5Qo8XSGzrMSJTdPWUQDo1DkunIRBfAS0crQaP9bZCSKNjqYJdYWVov0hDXw==}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  protocol-buffers-schema@3.6.0:
+    resolution: {integrity: sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2883,6 +3108,10 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-lru@6.1.2:
+    resolution: {integrity: sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==}
+    engines: {node: '>=12'}
 
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
@@ -2903,6 +3132,18 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -2910,6 +3151,10 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  reproject@1.2.7:
+    resolution: {integrity: sha512-x3wGpoHBsXDa1iyZZA3Nn52iTgzfLLPBLvsj1j4v3Kwcy3if5IRgi/s/Ayy/qAIm6BsjCwnuojShpfYG+FBAjA==}
+    hasBin: true
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -2921,6 +3166,9 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve-protobuf-schema@2.1.0:
+    resolution: {integrity: sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==}
 
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
@@ -2947,6 +3195,9 @@ packages:
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
@@ -3034,11 +3285,17 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  split@1.0.1:
+    resolution: {integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==}
+
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -3046,6 +3303,9 @@ packages:
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  stream-combiner@0.2.2:
+    resolution: {integrity: sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==}
 
   string.prototype.includes@2.0.1:
     resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
@@ -3069,6 +3329,9 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -3114,6 +3377,9 @@ packages:
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
+
+  through@2.3.8:
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -3181,6 +3447,9 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
+  typedarray@0.0.6:
+    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -3208,6 +3477,18 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+
+  uuid@3.4.0:
+    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
+    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    hasBin: true
 
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
@@ -3283,9 +3564,15 @@ packages:
       jsdom:
         optional: true
 
+  vt-pbf@3.1.3:
+    resolution: {integrity: sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==}
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
+
+  web-worker@1.5.0:
+    resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
 
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
@@ -3330,6 +3617,9 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wkt-parser@1.5.3:
+    resolution: {integrity: sha512-myla+RrMj+WTlnHc8Y4HEwjBcBF9dqJ3vjff/zmlrn9V3OKOM1mZVIyNjlPEmOM9Jjr/PPut0tnaTs9NyHcK8Q==}
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -3338,8 +3628,15 @@ packages:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
 
+  xml-utils@1.10.2:
+    resolution: {integrity: sha512-RqM+2o1RYs6T8+3DzDSoTRAUfrvaejbVHcp3+thnAtDKo8LskR+HomLajEy5UjTz24rpka7AxVBRR3g2wTUkJA==}
+
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  xmldom@0.6.0:
+    resolution: {integrity: sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==}
+    engines: {node: '>=10.0.0'}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -3354,6 +3651,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zstddec@0.2.0:
+    resolution: {integrity: sha512-oyPnDa1X5c13+Y7mA/FDMNJrn4S8UNBe0KCqtDmor40Re7ALrPN6npFwyYVRRh+PqozZQdeg23QtbcamZnG5rA==}
 
 snapshots:
 
@@ -3940,8 +4240,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/colour@1.1.0':
-    optional: true
+  '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -4037,6 +4336,10 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@ioredis/commands@1.5.0': {}
+
+  '@ioredis/commands@1.5.1': {}
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4055,6 +4358,30 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@mapbox/point-geometry@0.1.0': {}
+
+  '@mapbox/vector-tile@1.3.1':
+    dependencies:
+      '@mapbox/point-geometry': 0.1.0
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    optional: true
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -4288,6 +4615,31 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@turf/helpers@7.3.4':
+    dependencies:
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/invariant@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/line-offset@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/meta@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -4328,6 +4680,8 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -4560,6 +4914,11 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
+  JSONStream@1.3.5:
+    dependencies:
+      jsonparse: 1.3.1
+      through: 2.3.8
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -4591,6 +4950,8 @@ snapshots:
 
   aria-query@5.3.2: {}
 
+  arr-flatten@1.1.0: {}
+
   array-buffer-byte-length@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -4606,6 +4967,10 @@ snapshots:
       get-intrinsic: 1.3.0
       is-string: 1.1.1
       math-intrinsics: 1.1.0
+
+  array-parallel@0.1.3: {}
+
+  array-series@0.1.5: {}
 
   array.prototype.findlast@1.2.5:
     dependencies:
@@ -4680,6 +5045,8 @@ snapshots:
 
   bcryptjs@3.0.3: {}
 
+  bezier-js@2.6.1: {}
+
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
@@ -4706,6 +5073,18 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
   buffer-from@1.1.2: {}
+
+  bullmq@5.70.1:
+    dependencies:
+      cron-parser: 4.9.0
+      ioredis: 5.9.3
+      msgpackr: 1.11.5
+      node-abort-controller: 3.1.1
+      semver: 7.7.4
+      tslib: 2.8.1
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -4739,15 +5118,30 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.2: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
 
+  commander@6.2.1: {}
+
   concat-map@0.0.1: {}
 
+  concat-stream@2.0.0:
+    dependencies:
+      buffer-from: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      typedarray: 0.0.6
+
   convert-source-map@2.0.0: {}
+
+  cron-parser@4.9.0:
+    dependencies:
+      luxon: 3.7.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4820,6 +5214,8 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  denque@2.1.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -4854,6 +5250,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  duplexer@0.1.2: {}
 
   electron-to-chromium@1.5.302: {}
 
@@ -5264,6 +5662,16 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  event-stream@4.0.1:
+    dependencies:
+      duplexer: 0.1.2
+      from: 0.1.7
+      map-stream: 0.0.7
+      pause-stream: 0.0.11
+      split: 1.0.1
+      stream-combiner: 0.2.2
+      through: 2.3.8
+
   events@3.3.0: {}
 
   expect-type@1.3.0: {}
@@ -5321,6 +5729,8 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  from@0.1.7: {}
+
   fsevents@2.3.3:
     optional: true
 
@@ -5351,6 +5761,24 @@ snapshots:
   generator-function@2.0.1: {}
 
   gensync@1.0.0-beta.2: {}
+
+  geojson-stream@0.1.0:
+    dependencies:
+      JSONStream: 1.3.5
+      through: 2.3.8
+
+  geojson-vt@3.2.1: {}
+
+  geotiff@3.0.4:
+    dependencies:
+      '@petamoriken/float16': 3.9.3
+      lerc: 3.0.0
+      pako: 2.1.0
+      parse-headers: 2.0.6
+      quick-lru: 6.1.2
+      web-worker: 1.5.0
+      xml-utils: 1.10.2
+      zstddec: 0.2.0
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -5394,6 +5822,15 @@ snapshots:
     dependencies:
       define-properties: 1.2.1
       gopd: 1.2.0
+
+  gm@1.25.1:
+    dependencies:
+      array-parallel: 0.1.3
+      array-series: 0.1.5
+      cross-spawn: 7.0.6
+      debug: 3.2.7
+    transitivePeerDependencies:
+      - supports-color
 
   gopd@1.2.0: {}
 
@@ -5441,6 +5878,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -5452,11 +5891,41 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  inherits@2.0.4: {}
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  ioredis@5.10.0:
+    dependencies:
+      '@ioredis/commands': 1.5.1
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  ioredis@5.9.3:
+    dependencies:
+      '@ioredis/commands': 1.5.0
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -5638,6 +6107,8 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonparse@1.3.1: {}
+
   jsx-ast-utils@3.3.5:
     dependencies:
       array-includes: 3.1.9
@@ -5654,6 +6125,8 @@ snapshots:
   language-tags@1.0.9:
     dependencies:
       language-subtag-registry: 0.3.23
+
+  lerc@3.0.0: {}
 
   levn@0.4.1:
     dependencies:
@@ -5713,6 +6186,10 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.defaults@4.2.0: {}
+
+  lodash.isarguments@3.1.0: {}
+
   lodash.merge@4.6.2: {}
 
   loose-envify@1.4.0:
@@ -5725,17 +6202,23 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  luxon@3.7.2: {}
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  map-stream@0.0.7: {}
+
   math-intrinsics@1.1.0: {}
 
   mdn-data@2.12.2: {}
 
   merge2@1.4.1: {}
+
+  mgrs@1.0.0: {}
 
   micromatch@4.0.8:
     dependencies:
@@ -5752,7 +6235,25 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  mkdirp@1.0.4: {}
+
   ms@2.1.3: {}
+
+  msgpackr-extract@3.0.3:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
+    optional: true
+
+  msgpackr@1.11.5:
+    optionalDependencies:
+      msgpackr-extract: 3.0.3
 
   nanoid@3.3.11: {}
 
@@ -5789,12 +6290,19 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-abort-controller@3.1.1: {}
+
   node-exports-info@1.6.0:
     dependencies:
       array.prototype.flatmap: 1.3.3
       es-errors: 1.3.0
       object.entries: 1.1.9
       semver: 6.3.1
+
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
 
   node-releases@2.0.27: {}
 
@@ -5844,6 +6352,22 @@ snapshots:
 
   obug@2.1.1: {}
 
+  ocad2geojson@2.1.20:
+    dependencies:
+      '@turf/line-offset': 7.3.4
+      '@turf/meta': 7.3.4
+      '@types/geojson': 7946.0.16
+      arr-flatten: 1.1.0
+      bezier-js: 2.6.1
+      commander: 6.2.1
+      geojson-vt: 3.2.1
+      minimist: 1.2.8
+      mkdirp: 1.0.4
+      reproject: 1.2.7
+      uuid: 3.4.0
+      vt-pbf: 3.1.3
+      xmldom: 0.6.0
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -5867,9 +6391,13 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  pako@2.1.0: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-headers@2.0.6: {}
 
   parse5@8.0.0:
     dependencies:
@@ -5882,6 +6410,21 @@ snapshots:
   path-parse@1.0.7: {}
 
   pathe@2.0.3: {}
+
+  pause-stream@0.0.11:
+    dependencies:
+      through: 2.3.8
+
+  pbf@3.3.0:
+    dependencies:
+      ieee754: 1.2.1
+      resolve-protobuf-schema: 2.1.0
+
+  pdf2pic@3.2.0:
+    dependencies:
+      gm: 1.25.1
+    transitivePeerDependencies:
+      - supports-color
 
   pg-cloudflare@1.3.0:
     optional: true
@@ -5962,15 +6505,24 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  proj4@2.20.3:
+    dependencies:
+      mgrs: 1.0.0
+      wkt-parser: 1.5.3
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  protocol-buffers-schema@3.6.0: {}
+
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  quick-lru@6.1.2: {}
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:
@@ -5984,6 +6536,18 @@ snapshots:
   react-refresh@0.18.0: {}
 
   react@19.2.4: {}
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -6005,11 +6569,23 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  reproject@1.2.7:
+    dependencies:
+      concat-stream: 2.0.0
+      event-stream: 4.0.1
+      geojson-stream: 0.1.0
+      minimist: 1.2.8
+      proj4: 2.20.3
+
   require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  resolve-protobuf-schema@2.1.0:
+    dependencies:
+      protocol-buffers-schema: 3.6.0
 
   resolve@1.22.11:
     dependencies:
@@ -6070,6 +6646,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-symbols: 1.1.0
       isarray: 2.0.5
+
+  safe-buffer@5.2.1: {}
 
   safe-push-apply@1.0.0:
     dependencies:
@@ -6144,7 +6722,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -6195,9 +6772,15 @@ snapshots:
 
   split2@4.2.0: {}
 
+  split@1.0.1:
+    dependencies:
+      through: 2.3.8
+
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
+
+  standard-as-callback@2.1.0: {}
 
   std-env@3.10.0: {}
 
@@ -6205,6 +6788,11 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  stream-combiner@0.2.2:
+    dependencies:
+      duplexer: 0.1.2
+      through: 2.3.8
 
   string.prototype.includes@2.0.1:
     dependencies:
@@ -6256,6 +6844,10 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   strip-bom@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
@@ -6282,6 +6874,8 @@ snapshots:
   tailwindcss@4.2.1: {}
 
   tapable@2.3.0: {}
+
+  through@2.3.8: {}
 
   tinybench@2.9.0: {}
 
@@ -6362,6 +6956,8 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
+  typedarray@0.0.6: {}
+
   typescript@5.9.3: {}
 
   unbox-primitive@1.1.0:
@@ -6408,6 +7004,12 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  util-deprecate@1.0.2: {}
+
+  uuid@11.1.0: {}
+
+  uuid@3.4.0: {}
 
   vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1):
     dependencies:
@@ -6461,9 +7063,17 @@ snapshots:
       - tsx
       - yaml
 
+  vt-pbf@3.1.3:
+    dependencies:
+      '@mapbox/point-geometry': 0.1.0
+      '@mapbox/vector-tile': 1.3.1
+      pbf: 3.3.0
+
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
+
+  web-worker@1.5.0: {}
 
   webidl-conversions@8.0.1: {}
 
@@ -6531,11 +7141,17 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wkt-parser@1.5.3: {}
+
   word-wrap@1.2.5: {}
 
   xml-name-validator@5.0.0: {}
 
+  xml-utils@1.10.2: {}
+
   xmlchars@2.2.0: {}
+
+  xmldom@0.6.0: {}
 
   xtend@4.0.2: {}
 
@@ -6544,3 +7160,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@3.25.76: {}
+
+  zstddec@0.2.0: {}

--- a/src/env.ts
+++ b/src/env.ts
@@ -7,6 +7,8 @@ const envSchema = z.object({
   // Azure Blob Storage — optional; omit for local filesystem fallback in dev
   AZURE_STORAGE_ACCOUNT_NAME: z.string().optional(),
   AZURE_STORAGE_SAS_TOKEN: z.string().optional(),
+  // Redis — optional; defaults to localhost for dev
+  REDIS_URL: z.string().url().default('redis://localhost:6379'),
 })
 
 export const env = envSchema.parse(process.env)

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,6 @@
+export const register = async (): Promise<void> => {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { startWorker } = await import('./server/processing/worker')
+    startWorker()
+  }
+}

--- a/src/lib/storage/blob-client.ts
+++ b/src/lib/storage/blob-client.ts
@@ -3,6 +3,96 @@ import path from 'path'
 import { env } from '@/env'
 
 /**
+ * Downloads a file from wherever it was originally stored.
+ *
+ * Local `local:` URI → read from `.local-storage/` filesystem.
+ * Azure URL → download via BlobServiceClient.
+ */
+export const downloadFile = async (fileUrl: string): Promise<Buffer> => {
+  if (fileUrl.startsWith('local:')) {
+    const relativePath = fileUrl.slice('local:'.length)
+    const fullPath = path.join(process.cwd(), '.local-storage', relativePath)
+    return fs.readFile(fullPath)
+  }
+
+  const { BlobServiceClient } = await import('@azure/storage-blob')
+  const blobServiceClient = new BlobServiceClient(
+    `https://${env.AZURE_STORAGE_ACCOUNT_NAME}.blob.core.windows.net?${env.AZURE_STORAGE_SAS_TOKEN}`,
+  )
+  const url = new URL(fileUrl)
+  const parts = url.pathname.split('/').filter(Boolean)
+  const containerName = parts[0] ?? 'originals'
+  const blobName = parts.slice(1).join('/')
+  const containerClient = blobServiceClient.getContainerClient(containerName)
+  const blobClient = containerClient.getBlobClient(blobName)
+  const response = await blobClient.download()
+  const chunks: Buffer[] = []
+  for await (const chunk of response.readableStreamBody as AsyncIterable<Buffer>) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  }
+  return Buffer.concat(chunks)
+}
+
+/**
+ * Uploads a processed map file (e.g. optimised PNG, GeoJSON) to the processed store.
+ *
+ * Returns the URL to persist in the DB.
+ */
+export const uploadProcessed = async (
+  mapId: string,
+  fileName: string,
+  data: Buffer,
+  contentType: string,
+): Promise<string> => {
+  if (env.AZURE_STORAGE_ACCOUNT_NAME && env.AZURE_STORAGE_SAS_TOKEN) {
+    const { BlobServiceClient } = await import('@azure/storage-blob')
+    const blobServiceClient = new BlobServiceClient(
+      `https://${env.AZURE_STORAGE_ACCOUNT_NAME}.blob.core.windows.net?${env.AZURE_STORAGE_SAS_TOKEN}`,
+    )
+    const containerClient = blobServiceClient.getContainerClient('processed')
+    const blobName = `${mapId}/${fileName}`
+    const blockBlobClient = containerClient.getBlockBlobClient(blobName)
+    await blockBlobClient.uploadData(data, { blobHTTPHeaders: { blobContentType: contentType } })
+    return blockBlobClient.url
+  }
+
+  const dir = path.join(process.cwd(), '.local-storage', 'processed', mapId)
+  await fs.mkdir(dir, { recursive: true })
+  await fs.writeFile(path.join(dir, fileName), data)
+  return `local:processed/${mapId}/${fileName}`
+}
+
+/**
+ * Uploads a map tile to the tiles store.
+ *
+ * Returns the URL (Azure blob URL or local: URI).
+ */
+export const uploadTile = async (
+  mapId: string,
+  z: number,
+  x: number,
+  y: number,
+  data: Buffer,
+): Promise<string> => {
+  if (env.AZURE_STORAGE_ACCOUNT_NAME && env.AZURE_STORAGE_SAS_TOKEN) {
+    const { BlobServiceClient } = await import('@azure/storage-blob')
+    const blobServiceClient = new BlobServiceClient(
+      `https://${env.AZURE_STORAGE_ACCOUNT_NAME}.blob.core.windows.net?${env.AZURE_STORAGE_SAS_TOKEN}`,
+    )
+    const containerClient = blobServiceClient.getContainerClient('tiles')
+    const blobName = `${mapId}/${z}/${x}/${y}.png`
+    const blockBlobClient = containerClient.getBlockBlobClient(blobName)
+    await blockBlobClient.uploadData(data, { blobHTTPHeaders: { blobContentType: 'image/png' } })
+    return blockBlobClient.url
+  }
+
+  const dir = path.join(process.cwd(), '.local-storage', 'tiles', mapId, String(z), String(x))
+  await fs.mkdir(dir, { recursive: true })
+  await fs.writeFile(path.join(dir, `${y}.png`), data)
+  return `local:tiles/${mapId}/${z}/${x}/${y}.png`
+}
+
+/**
  * Uploads a map file to the originals store.
  *
  * Production: Azure Blob Storage (requires AZURE_STORAGE_ACCOUNT_NAME + AZURE_STORAGE_SAS_TOKEN).

--- a/src/server/maps/actions.ts
+++ b/src/server/maps/actions.ts
@@ -8,6 +8,7 @@ import { auth } from '@/server/auth'
 import { db } from '@/server/db'
 import { maps, originalFormatEnum } from '@/server/db/schema'
 import { deleteOriginal, uploadOriginal } from '@/lib/storage/blob-client'
+import { mapProcessingQueue } from '@/server/processing/queue'
 
 type OriginalFormat = (typeof originalFormatEnum.enumValues)[number]
 
@@ -106,6 +107,12 @@ export const uploadMapAction = async (
     yearUpdated: parsed.data.yearUpdated ?? null,
     cartographer: parsed.data.cartographer ?? null,
     publisher: parsed.data.publisher ?? null,
+  })
+
+  await mapProcessingQueue.add('process-map', {
+    mapId,
+    originalFileUrl,
+    originalFormat: format,
   })
 
   redirect('/maps')

--- a/src/server/processing/image.test.ts
+++ b/src/server/processing/image.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockToBuffer = vi.fn()
+const mockPng = vi.fn()
+const mockResize = vi.fn()
+
+vi.mock('sharp', () => {
+  const chain = {
+    resize: mockResize,
+    png: mockPng,
+    toBuffer: mockToBuffer,
+  }
+  mockResize.mockReturnValue(chain)
+  mockPng.mockReturnValue(chain)
+  return { default: vi.fn(() => chain) }
+})
+
+describe('processImage', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mockToBuffer.mockResolvedValue(Buffer.from('processed'))
+  })
+
+  it('calls resize and png and returns the buffer', async () => {
+    const { processImage } = await import('./image')
+    const input = Buffer.from('raw-image-data')
+    const result = await processImage(input)
+
+    expect(mockResize).toHaveBeenCalledWith({
+      width: 4000,
+      height: 4000,
+      fit: 'inside',
+      withoutEnlargement: true,
+    })
+    expect(mockPng).toHaveBeenCalledWith({ compressionLevel: 8 })
+    expect(result).toEqual(Buffer.from('processed'))
+  })
+})

--- a/src/server/processing/image.ts
+++ b/src/server/processing/image.ts
@@ -1,0 +1,7 @@
+import sharp from 'sharp'
+
+export const processImage = async (input: Buffer): Promise<Buffer> =>
+  sharp(input)
+    .resize({ width: 4000, height: 4000, fit: 'inside', withoutEnlargement: true })
+    .png({ compressionLevel: 8 })
+    .toBuffer()

--- a/src/server/processing/ocad.test.ts
+++ b/src/server/processing/ocad.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { FeatureCollection } from 'geojson'
+
+const mockReadOcad = vi.fn()
+const mockOcadToGeoJson = vi.fn()
+
+vi.mock('ocad2geojson', () => ({
+  readOcad: mockReadOcad,
+  ocadToGeoJson: mockOcadToGeoJson,
+}))
+
+describe('convertOcadToGeoJson', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('returns a JSON buffer of the GeoJSON feature collection', async () => {
+    const fakeOcadFile = { parsed: true }
+    const fakeGeoJson: FeatureCollection = {
+      type: 'FeatureCollection',
+      features: [{ type: 'Feature', geometry: { type: 'Point', coordinates: [0, 0] }, properties: {} }],
+    }
+    mockReadOcad.mockResolvedValue(fakeOcadFile)
+    mockOcadToGeoJson.mockReturnValue(fakeGeoJson)
+
+    const { convertOcadToGeoJson } = await import('./ocad')
+    const result = await convertOcadToGeoJson(Buffer.from('ocad-data'))
+
+    expect(mockReadOcad).toHaveBeenCalled()
+    expect(mockOcadToGeoJson).toHaveBeenCalledWith(fakeOcadFile)
+    expect(JSON.parse(result.toString('utf-8'))).toEqual(fakeGeoJson)
+  })
+})

--- a/src/server/processing/ocad.ts
+++ b/src/server/processing/ocad.ts
@@ -1,0 +1,11 @@
+import { readOcad, ocadToGeoJson } from 'ocad2geojson'
+
+export const convertOcadToGeoJson = async (buffer: Buffer): Promise<Buffer> => {
+  const arrayBuffer = buffer.buffer.slice(
+    buffer.byteOffset,
+    buffer.byteOffset + buffer.byteLength,
+  ) as ArrayBuffer
+  const ocadFile = await readOcad(arrayBuffer)
+  const geojson = ocadToGeoJson(ocadFile)
+  return Buffer.from(JSON.stringify(geojson), 'utf-8')
+}

--- a/src/server/processing/pdf.test.ts
+++ b/src/server/processing/pdf.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockConvertFn = vi.fn()
+const mockFromBuffer = vi.fn(() => mockConvertFn)
+const mockProcessImage = vi.fn()
+const mockMkdtemp = vi.fn()
+const mockMkdir = vi.fn()
+const mockRm = vi.fn()
+
+vi.mock('pdf2pic', () => ({ fromBuffer: mockFromBuffer }))
+
+vi.mock('./image', () => ({ processImage: mockProcessImage }))
+
+vi.mock('fs/promises', () => ({
+  default: {
+    mkdtemp: mockMkdtemp,
+    mkdir: mockMkdir,
+    rm: mockRm,
+  },
+}))
+
+describe('convertPdfToBuffer', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mockMkdtemp.mockResolvedValue('/tmp/omap-pdf-abc')
+    mockMkdir.mockResolvedValue(undefined)
+    mockRm.mockResolvedValue(undefined)
+    mockProcessImage.mockResolvedValue(Buffer.from('processed-png'))
+  })
+
+  it('returns the processed image buffer', async () => {
+    mockConvertFn.mockResolvedValue({ buffer: Buffer.from('pdf-page-png') })
+
+    const { convertPdfToBuffer } = await import('./pdf')
+    const result = await convertPdfToBuffer(Buffer.from('pdf-data'))
+
+    expect(mockFromBuffer).toHaveBeenCalled()
+    expect(mockProcessImage).toHaveBeenCalledWith(Buffer.from('pdf-page-png'))
+    expect(result).toEqual(Buffer.from('processed-png'))
+    expect(mockRm).toHaveBeenCalledWith('/tmp/omap-pdf-abc', { recursive: true, force: true })
+  })
+
+  it('throws when pdf2pic returns no buffer', async () => {
+    mockConvertFn.mockResolvedValue({ buffer: null })
+
+    const { convertPdfToBuffer } = await import('./pdf')
+    await expect(convertPdfToBuffer(Buffer.from('pdf-data'))).rejects.toThrow(
+      'pdf2pic returned no buffer',
+    )
+    expect(mockRm).toHaveBeenCalledWith('/tmp/omap-pdf-abc', { recursive: true, force: true })
+  })
+})

--- a/src/server/processing/pdf.ts
+++ b/src/server/processing/pdf.ts
@@ -1,0 +1,24 @@
+import os from 'os'
+import path from 'path'
+import fs from 'fs/promises'
+import { fromBuffer } from 'pdf2pic'
+import { processImage } from './image'
+
+// NOTE: requires GraphicsMagick or ImageMagick installed on the host
+export const convertPdfToBuffer = async (pdfBuffer: Buffer): Promise<Buffer> => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'omap-pdf-'))
+  try {
+    const savePath = path.join(tmpDir, 'out')
+    await fs.mkdir(savePath)
+    const result = await fromBuffer(pdfBuffer, {
+      density: 150,
+      savePath,
+      saveFilename: 'page',
+      format: 'png',
+    })(1, { responseType: 'buffer' })
+    if (!result.buffer) throw new Error('pdf2pic returned no buffer')
+    return processImage(result.buffer)
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  }
+}

--- a/src/server/processing/queue.ts
+++ b/src/server/processing/queue.ts
@@ -1,0 +1,39 @@
+import { Queue } from 'bullmq'
+import { env } from '@/env'
+
+export type MapProcessingJobData = {
+  mapId: string
+  originalFileUrl: string
+  originalFormat: 'jpeg' | 'png' | 'pdf' | 'geotiff' | 'ocad' | 'oom'
+}
+
+type RedisConnectionOptions = {
+  host: string
+  port: number
+  username?: string
+  password?: string
+  maxRetriesPerRequest: null
+}
+
+const parseRedisUrl = (url: string): RedisConnectionOptions => {
+  const parsed = new URL(url)
+  return {
+    host: parsed.hostname,
+    port: parsed.port ? parseInt(parsed.port, 10) : 6379,
+    username: parsed.username || undefined,
+    password: parsed.password || undefined,
+    maxRetriesPerRequest: null,
+  }
+}
+
+export const getRedisOptions = (): RedisConnectionOptions => parseRedisUrl(env.REDIS_URL)
+
+export const mapProcessingQueue = new Queue<MapProcessingJobData, void, string>('map-processing', {
+  connection: getRedisOptions(),
+  defaultJobOptions: {
+    attempts: 3,
+    backoff: { type: 'exponential', delay: 2000 },
+    removeOnComplete: { count: 100 },
+    removeOnFail: { count: 500 },
+  },
+})

--- a/src/server/processing/tiles.test.ts
+++ b/src/server/processing/tiles.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// --- sharp mock ---
+const mockSharpToBuffer = vi.fn()
+const mockSharpPng = vi.fn()
+const mockSharpResize = vi.fn()
+const mockSharpExtract = vi.fn()
+const mockSharpRaw = vi.fn()
+
+const sharpChain = {
+  resize: mockSharpResize,
+  png: mockSharpPng,
+  toBuffer: mockSharpToBuffer,
+  extract: mockSharpExtract,
+  raw: mockSharpRaw,
+}
+mockSharpResize.mockReturnValue(sharpChain)
+mockSharpPng.mockReturnValue(sharpChain)
+mockSharpExtract.mockReturnValue(sharpChain)
+mockSharpRaw.mockReturnValue(sharpChain)
+
+vi.mock('sharp', () => ({ default: vi.fn(() => sharpChain) }))
+
+// --- geotiff mock ---
+const mockGetWidth = vi.fn(() => 512)
+const mockGetHeight = vi.fn(() => 512)
+const mockGetSamplesPerPixel = vi.fn(() => 3)
+const mockReadRasters = vi.fn()
+const mockGetImage = vi.fn()
+const mockFromArrayBuffer = vi.fn()
+
+vi.mock('geotiff', () => ({ fromArrayBuffer: mockFromArrayBuffer }))
+
+describe('isLargeImage', () => {
+  it('returns true when max dimension >= 4000', async () => {
+    const { isLargeImage } = await import('./tiles')
+    expect(isLargeImage(4000, 100)).toBe(true)
+    expect(isLargeImage(100, 5000)).toBe(true)
+    expect(isLargeImage(3999, 3999)).toBe(false)
+  })
+})
+
+describe('readGeoTiffToBuffer', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mockGetWidth.mockReturnValue(512)
+    mockGetHeight.mockReturnValue(512)
+    mockGetSamplesPerPixel.mockReturnValue(3)
+    mockReadRasters.mockResolvedValue(new Uint8Array(512 * 512 * 3))
+    mockGetImage.mockResolvedValue({
+      getWidth: mockGetWidth,
+      getHeight: mockGetHeight,
+      getSamplesPerPixel: mockGetSamplesPerPixel,
+      readRasters: mockReadRasters,
+    })
+    mockFromArrayBuffer.mockResolvedValue({ getImage: mockGetImage })
+    mockSharpToBuffer.mockResolvedValue(Buffer.from('png-data'))
+  })
+
+  it('returns png buffer, width, and height', async () => {
+    const { readGeoTiffToBuffer } = await import('./tiles')
+    const result = await readGeoTiffToBuffer(Buffer.from('tiff-data'))
+
+    expect(result.width).toBe(512)
+    expect(result.height).toBe(512)
+    expect(result.png).toEqual(Buffer.from('png-data'))
+  })
+})
+
+describe('generateTiles', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mockSharpToBuffer.mockResolvedValue(Buffer.from('tile'))
+  })
+
+  it('generates the correct number of tiles for a 512x512 image', async () => {
+    const { generateTiles } = await import('./tiles')
+    // 512x512: maxZ = ceil(log2(512/256)) = ceil(1) = 1
+    // z=0: scale=0.5 → sw=sh=256, 1x1 tile = 1 tile
+    // z=1: scale=1   → sw=sh=512, 2x2 tiles = 4 tiles
+    // total = 5
+    const tiles = await generateTiles(Buffer.from('png'), 512, 512)
+    expect(tiles.length).toBe(5)
+    expect(tiles[0]).toMatchObject({ z: 0, x: 0, y: 0 })
+  })
+})

--- a/src/server/processing/tiles.ts
+++ b/src/server/processing/tiles.ts
@@ -1,0 +1,66 @@
+import { fromArrayBuffer } from 'geotiff'
+import sharp from 'sharp'
+
+const TILE_SIZE = 256
+const LARGE_IMAGE_THRESHOLD = 4000
+
+export type TileResult = { z: number; x: number; y: number; buffer: Buffer }
+
+export const readGeoTiffToBuffer = async (
+  input: Buffer,
+): Promise<{ png: Buffer; width: number; height: number }> => {
+  const tiff = await fromArrayBuffer(
+    input.buffer.slice(input.byteOffset, input.byteOffset + input.byteLength) as ArrayBuffer,
+  )
+  const image = await tiff.getImage()
+  const width = image.getWidth()
+  const height = image.getHeight()
+  const rasters = await image.readRasters({ interleave: true })
+  const channels = image.getSamplesPerPixel() as 1 | 2 | 3 | 4
+  // readRasters with interleave: true returns a single TypedArray; cast via unknown to extract buffer
+  const rasterArray = rasters as unknown as Uint8Array
+  const png = await sharp(Buffer.from(rasterArray.buffer, rasterArray.byteOffset, rasterArray.byteLength), {
+    raw: { width, height, channels },
+  })
+    .png({ compressionLevel: 8 })
+    .toBuffer()
+  return { png, width, height }
+}
+
+export const generateTiles = async (
+  png: Buffer,
+  width: number,
+  height: number,
+): Promise<TileResult[]> => {
+  const maxDim = Math.max(width, height)
+  const maxZ = Math.ceil(Math.log2(maxDim / TILE_SIZE))
+  const tiles: TileResult[] = []
+
+  for (let z = 0; z <= maxZ; z++) {
+    const scale = Math.pow(2, z - maxZ)
+    const sw = Math.max(1, Math.round(width * scale))
+    const sh = Math.max(1, Math.round(height * scale))
+    const tilesX = Math.ceil(sw / TILE_SIZE)
+    const tilesY = Math.ceil(sh / TILE_SIZE)
+    const scaled = await sharp(png).resize(sw, sh, { fit: 'contain' }).png().toBuffer()
+    for (let x = 0; x < tilesX; x++) {
+      for (let y = 0; y < tilesY; y++) {
+        const tileW = Math.min(TILE_SIZE, sw - x * TILE_SIZE)
+        const tileH = Math.min(TILE_SIZE, sh - y * TILE_SIZE)
+        const tileBuffer = await sharp(scaled)
+          .extract({ left: x * TILE_SIZE, top: y * TILE_SIZE, width: tileW, height: tileH })
+          .resize(TILE_SIZE, TILE_SIZE, {
+            fit: 'contain',
+            background: { r: 0, g: 0, b: 0, alpha: 0 },
+          })
+          .png()
+          .toBuffer()
+        tiles.push({ z, x, y, buffer: tileBuffer })
+      }
+    }
+  }
+  return tiles
+}
+
+export const isLargeImage = (width: number, height: number): boolean =>
+  Math.max(width, height) >= LARGE_IMAGE_THRESHOLD

--- a/src/server/processing/worker.test.ts
+++ b/src/server/processing/worker.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// --- bullmq mock ---
+let capturedProcessor: ((job: unknown) => Promise<void>) | null = null
+let capturedFailedHandler: ((job: unknown, err: Error) => void) | null = null
+
+const mockWorkerOn = vi.fn((event: string, handler: (job: unknown, err: Error) => void) => {
+  if (event === 'failed') capturedFailedHandler = handler
+})
+
+class MockWorkerClass {
+  constructor(_queue: string, processor: (job: unknown) => Promise<void>) {
+    capturedProcessor = processor
+  }
+  on = mockWorkerOn
+  close = vi.fn()
+}
+const MockWorker = vi.fn(function MockWorker(
+  this: MockWorkerClass,
+  queue: string,
+  processor: (job: unknown) => Promise<void>,
+) {
+  capturedProcessor = processor
+  this.on = mockWorkerOn
+  this.close = vi.fn()
+} as unknown as typeof MockWorkerClass)
+
+vi.mock('bullmq', () => ({
+  Worker: MockWorker,
+  Queue: vi.fn(function MockQueue(this: object) {
+    return { add: vi.fn() }
+  }),
+}))
+
+// --- queue mock (avoids Queue instantiation at module load) ---
+vi.mock('./queue', () => ({
+  getRedisOptions: vi.fn(() => ({ host: 'localhost', port: 6379, maxRetriesPerRequest: null })),
+  mapProcessingQueue: { add: vi.fn() },
+}))
+
+// --- env mock ---
+vi.mock('@/env', () => ({ env: { REDIS_URL: 'redis://localhost:6379' } }))
+
+// --- db mock ---
+const mockDbWhere = vi.fn()
+const mockDbSet = vi.fn()
+const mockDbUpdate = vi.fn()
+mockDbSet.mockReturnValue({ where: mockDbWhere })
+mockDbWhere.mockResolvedValue(undefined)
+mockDbUpdate.mockReturnValue({ set: mockDbSet })
+vi.mock('@/server/db', () => ({ db: { update: mockDbUpdate } }))
+
+// --- schema mock ---
+vi.mock('@/server/db/schema', () => ({ maps: {} }))
+
+// --- blob-client mock ---
+const mockDownloadFile = vi.fn()
+const mockUploadProcessed = vi.fn()
+const mockUploadTile = vi.fn()
+vi.mock('@/lib/storage/blob-client', () => ({
+  downloadFile: mockDownloadFile,
+  uploadProcessed: mockUploadProcessed,
+  uploadTile: mockUploadTile,
+}))
+
+// --- processing handler mocks ---
+const mockProcessImage = vi.fn()
+vi.mock('./image', () => ({ processImage: mockProcessImage }))
+
+const mockConvertPdfToBuffer = vi.fn()
+vi.mock('./pdf', () => ({ convertPdfToBuffer: mockConvertPdfToBuffer }))
+
+const mockConvertOcadToGeoJson = vi.fn()
+vi.mock('./ocad', () => ({ convertOcadToGeoJson: mockConvertOcadToGeoJson }))
+
+const mockReadGeoTiffToBuffer = vi.fn()
+const mockGenerateTiles = vi.fn()
+const mockIsLargeImage = vi.fn()
+vi.mock('./tiles', () => ({
+  readGeoTiffToBuffer: mockReadGeoTiffToBuffer,
+  generateTiles: mockGenerateTiles,
+  isLargeImage: mockIsLargeImage,
+}))
+
+describe('startWorker', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    capturedProcessor = null
+    capturedFailedHandler = null
+    mockDbSet.mockReturnValue({ where: mockDbWhere })
+    mockDbWhere.mockResolvedValue(undefined)
+    mockDbUpdate.mockReturnValue({ set: mockDbSet })
+    mockDownloadFile.mockResolvedValue(Buffer.from('file-data'))
+    mockUploadProcessed.mockResolvedValue('local:processed/map-id/map.png')
+  })
+
+  it('transitions status to ready for jpeg format', async () => {
+    mockProcessImage.mockResolvedValue(Buffer.from('optimised'))
+
+    const { startWorker } = await import('./worker')
+    startWorker()
+
+    expect(capturedProcessor).not.toBeNull()
+
+    const fakeJob = {
+      data: {
+        mapId: 'test-map-id',
+        originalFileUrl: 'local:originals/user/test-map-id/map.jpg',
+        originalFormat: 'jpeg',
+      },
+    }
+    await capturedProcessor!(fakeJob)
+
+    // First update: processing
+    expect(mockDbSet).toHaveBeenCalledWith({ processingStatus: 'processing' })
+
+    // Second update: ready
+    expect(mockDbSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        processingStatus: 'ready',
+        processedUrl: 'local:processed/map-id/map.png',
+      }),
+    )
+  })
+
+  it('failed event handler updates DB with error message', async () => {
+    const { startWorker } = await import('./worker')
+    startWorker()
+
+    expect(capturedFailedHandler).not.toBeNull()
+
+    const fakeJob = { data: { mapId: 'failed-map-id' } }
+    const fakeError = new Error('processing exploded')
+    capturedFailedHandler!(fakeJob, fakeError)
+
+    expect(mockDbSet).toHaveBeenCalledWith({
+      processingStatus: 'failed',
+      processingError: 'processing exploded',
+    })
+  })
+})

--- a/src/server/processing/worker.ts
+++ b/src/server/processing/worker.ts
@@ -1,0 +1,75 @@
+import { Worker } from 'bullmq'
+import { eq } from 'drizzle-orm'
+import { db } from '@/server/db'
+import { maps } from '@/server/db/schema'
+import { downloadFile, uploadProcessed, uploadTile } from '@/lib/storage/blob-client'
+import { getRedisOptions, type MapProcessingJobData } from './queue'
+import { processImage } from './image'
+import { convertPdfToBuffer } from './pdf'
+import { convertOcadToGeoJson } from './ocad'
+import { readGeoTiffToBuffer, generateTiles, isLargeImage } from './tiles'
+
+let worker: Worker | null = null
+
+export const startWorker = (): void => {
+  if (worker) return
+
+  worker = new Worker<MapProcessingJobData, void, string>(
+    'map-processing',
+    async (job) => {
+      const { mapId, originalFileUrl, originalFormat } = job.data
+
+      await db.update(maps).set({ processingStatus: 'processing' }).where(eq(maps.id, mapId))
+
+      const fileBuffer = await downloadFile(originalFileUrl)
+
+      let processedUrl: string | undefined
+      let tileBaseUrl: string | undefined
+
+      if (originalFormat === 'pdf') {
+        const png = await convertPdfToBuffer(fileBuffer)
+        processedUrl = await uploadProcessed(mapId, 'map.png', png, 'image/png')
+      } else if (originalFormat === 'ocad' || originalFormat === 'oom') {
+        const geojson = await convertOcadToGeoJson(fileBuffer)
+        processedUrl = await uploadProcessed(
+          mapId,
+          'map.geojson',
+          geojson,
+          'application/geo+json',
+        )
+      } else if (originalFormat === 'geotiff') {
+        const { png, width, height } = await readGeoTiffToBuffer(fileBuffer)
+        processedUrl = await uploadProcessed(mapId, 'map.png', png, 'image/png')
+        if (isLargeImage(width, height)) {
+          const tiles = await generateTiles(png, width, height)
+          await Promise.all(tiles.map((t) => uploadTile(mapId, t.z, t.x, t.y, t.buffer)))
+          tileBaseUrl = `tiles/${mapId}`
+        }
+      } else {
+        // jpeg / png
+        const optimised = await processImage(fileBuffer)
+        processedUrl = await uploadProcessed(mapId, 'map.png', optimised, 'image/png')
+      }
+
+      await db
+        .update(maps)
+        .set({ processingStatus: 'ready', processedUrl, tileBaseUrl: tileBaseUrl ?? null })
+        .where(eq(maps.id, mapId))
+    },
+    { connection: getRedisOptions() },
+  )
+
+  worker.on('failed', (job, err) => {
+    if (!job) return
+    const { mapId } = job.data as MapProcessingJobData
+    db.update(maps)
+      .set({ processingStatus: 'failed', processingError: err.message })
+      .where(eq(maps.id, mapId))
+      .catch(() => undefined) // best-effort
+  })
+}
+
+export const stopWorker = async (): Promise<void> => {
+  await worker?.close()
+  worker = null
+}

--- a/src/types/ocad2geojson.d.ts
+++ b/src/types/ocad2geojson.d.ts
@@ -1,0 +1,6 @@
+import type { FeatureCollection } from 'geojson'
+
+declare module 'ocad2geojson' {
+  export function readOcad(buffer: ArrayBuffer): Promise<unknown>
+  export function ocadToGeoJson(ocadFile: unknown): FeatureCollection
+}


### PR DESCRIPTION
## Summary

- Wires up the full async map processing pipeline so maps no longer stay stuck at `processingStatus: 'pending'`
- BullMQ worker starts automatically via `src/instrumentation.ts` on Next.js boot (Node.js runtime only)
- Supports all six upload formats: JPEG/PNG (→ optimised PNG), PDF (→ PNG via pdf2pic), OCAD/OOM (→ GeoJSON via ocad2geojson), GeoTIFF (→ PNG + optional tile pyramid via geotiff + sharp)
- Large GeoTIFF images (≥ 4000px) also generate a tile pyramid stored under `tiles/{mapId}`

## Changes

| Area | What changed |
|------|-------------|
| Infrastructure | Redis 7 service added to `docker-compose.yml`; `REDIS_URL` env var added with localhost default |
| Next.js config | `serverExternalPackages` for `sharp`, `pdf2pic`, `ioredis`, `bullmq`, `geotiff`, `ocad2geojson` |
| Blob client | `downloadFile`, `uploadProcessed`, `uploadTile` added to `blob-client.ts` |
| Processing modules | `queue.ts`, `worker.ts`, `image.ts`, `pdf.ts`, `ocad.ts`, `tiles.ts` under `src/server/processing/` |
| Worker boot | `src/instrumentation.ts` — Next.js instrumentation hook starts the worker |
| Upload action | `uploadMapAction` now enqueues a BullMQ job after the DB insert |
| Tests | 9 unit tests across 5 test files (all handlers + worker lifecycle) |

## Test plan

- [ ] `pnpm typecheck` — zero errors
- [ ] `pnpm lint` — zero errors
- [ ] `pnpm test` — 9/9 pass
- [ ] Manual: `docker compose up -d && pnpm dev` → upload JPEG → DB row transitions `pending → processing → ready`
- [ ] Manual: upload PDF → same status progression
- [ ] Manual: kill server mid-job → restart → BullMQ re-queues stalled job after lock expiry

🤖 Generated with [Claude Code](https://claude.com/claude-code)