### PR TITLE
chore(ci): add CodeQL analysis workflow on every PR

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,30 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * 1' # weekly Monday 03:00 UTC
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+
+      - uses: github/codeql-action/autobuild@v3
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:javascript-typescript


### PR DESCRIPTION
Closes #22

## Summary

- Adds `.github/workflows/codeql.yml` with CodeQL static analysis
- Triggers on push/PR to `main` and a weekly Monday 03:00 UTC schedule
- Scans `javascript-typescript` (covers all TS/JS in the repo)
- Results appear in the GitHub Security tab → Code scanning alerts

## Test plan

- [ ] Workflow appears and runs on this PR
- [ ] Check completes with zero high/critical findings
- [ ] Results visible in Security tab after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)