### PR TITLE
chore(ci): add SCA — Dependabot updates and pnpm audit on every PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: npm # pnpm uses the npm ecosystem
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "03:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -1,0 +1,29 @@
+name: SCA
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  audit:
+    name: pnpm audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run audit
+        run: pnpm audit --audit-level=high


### PR DESCRIPTION
Closes #24

## Summary

- **`.github/dependabot.yml`** — weekly Monday dependency update PRs via Dependabot (npm/pnpm ecosystem), labelled `dependencies`, commit prefix `chore(deps):`
- **`.github/workflows/sca.yml`** — runs `pnpm audit --audit-level=high` on every PR and push to `main`; fails the check if any high or critical CVE is present in the dependency tree

## Test plan

- [ ] SCA workflow appears and runs on this PR
- [ ] `pnpm audit` passes on the current dependency tree
- [ ] Dependabot PRs begin appearing on Mondays

🤖 Generated with [Claude Code](https://claude.com/claude-code)