### PR TITLE
feat(maps): add map detail page

### DIFF
--- a/src/app/(app)/maps/[id]/page.tsx
+++ b/src/app/(app)/maps/[id]/page.tsx
@@ -1,0 +1,134 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { headers } from 'next/headers'
+import { and, eq } from 'drizzle-orm'
+import { auth } from '@/server/auth'
+import { db } from '@/server/db'
+import { maps, mapGeoreferences } from '@/server/db/schema'
+import { MapFormatBadge } from '@/components/maps/MapFormatBadge'
+import { MapStatusBadge } from '@/components/maps/MapStatusBadge'
+import { MapViewer } from '@/components/maps/MapViewer'
+import { MapStatusPoller } from '@/components/maps/MapStatusPoller'
+import { ShareToggle } from '@/components/maps/ShareToggle'
+
+export const metadata: Metadata = { title: 'Map Detail — oMapArchive' }
+
+type Props = {
+  params: Promise<{ id: string }>
+}
+
+const MapDetailPage = async ({ params }: Props) => {
+  const { id: mapId } = await params
+  const session = await auth()
+  if (!session?.user?.id) return null
+
+  const row = await db
+    .select({ map: maps, georefId: mapGeoreferences.id })
+    .from(maps)
+    .leftJoin(mapGeoreferences, eq(mapGeoreferences.mapId, maps.id))
+    .where(and(eq(maps.id, mapId), eq(maps.userId, session.user.id)))
+    .then((r) => r[0] ?? null)
+
+  if (!row) notFound()
+
+  const { map, georefId } = row
+
+  const headersList = await headers()
+  const host = headersList.get('host') ?? 'localhost:3000'
+  const protocol = host.startsWith('localhost') ? 'http' : 'https'
+  const shareUrl = map.isPublic && map.shareToken
+    ? `${protocol}://${host}/share/${map.shareToken}`
+    : null
+
+  const uploadDate = new Intl.DateTimeFormat('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  }).format(new Date(map.uploadedAt))
+
+  const isActive = map.processingStatus === 'pending' || map.processingStatus === 'processing'
+  const canGeoreference = map.processingStatus === 'ready' && !georefId
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-2">
+        <Link
+          href="/maps"
+          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          ← My Maps
+        </Link>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-start gap-3">
+          <h1 className="text-2xl font-semibold leading-tight flex-1">{map.title}</h1>
+          <div className="flex flex-wrap gap-1.5 pt-1">
+            <MapFormatBadge format={map.originalFormat} />
+            <MapStatusBadge status={map.processingStatus} />
+          </div>
+        </div>
+
+        <dl className="flex flex-wrap gap-x-6 gap-y-1 text-sm text-muted-foreground">
+          {map.scale && (
+            <>
+              <dt className="sr-only">Scale</dt>
+              <dd>1&nbsp;:&nbsp;{map.scale.toLocaleString()}</dd>
+            </>
+          )}
+          {map.equidistance && (
+            <>
+              <dt className="sr-only">Equidistance</dt>
+              <dd>{map.equidistance}&nbsp;m</dd>
+            </>
+          )}
+          {map.yearUpdated && (
+            <>
+              <dt className="sr-only">Year</dt>
+              <dd>{map.yearUpdated}</dd>
+            </>
+          )}
+          {map.cartographer && (
+            <>
+              <dt className="sr-only">Cartographer</dt>
+              <dd>{map.cartographer}</dd>
+            </>
+          )}
+          {map.publisher && (
+            <>
+              <dt className="sr-only">Publisher</dt>
+              <dd>{map.publisher}</dd>
+            </>
+          )}
+          <dt className="sr-only">Uploaded</dt>
+          <dd>Uploaded {uploadDate}</dd>
+        </dl>
+      </div>
+
+      {isActive && (
+        <MapStatusPoller
+          mapId={map.id}
+          initialStatus={map.processingStatus as 'pending' | 'processing'}
+        />
+      )}
+
+      {map.processedUrl && <MapViewer src={map.processedUrl} alt={map.title} />}
+
+      {canGeoreference && (
+        <Link
+          href={`/maps/${map.id}/georeference`}
+          className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm hover:opacity-90 transition-opacity"
+        >
+          Georeference this map
+        </Link>
+      )}
+
+      <div className="rounded-lg border border-border p-4">
+        <ShareToggle mapId={map.id} isPublic={map.isPublic} shareUrl={shareUrl} />
+      </div>
+    </div>
+  )
+}
+
+export default MapDetailPage

--- a/src/components/maps/MapCard.tsx
+++ b/src/components/maps/MapCard.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import type { Map } from '@/server/db/schema'
 import { DeleteMapButton } from './DeleteMapButton'
 import { MapFormatBadge } from './MapFormatBadge'
@@ -17,7 +18,9 @@ export const MapCard = ({ map }: MapCardProps) => {
   return (
     <div className="rounded-lg border border-border bg-card p-4 shadow-sm hover:shadow-md transition-shadow space-y-3">
       <div>
-        <h3 className="font-medium text-card-foreground leading-tight line-clamp-2">{map.title}</h3>
+        <Link href={`/maps/${map.id}`} className="hover:underline">
+          <h3 className="font-medium text-card-foreground leading-tight line-clamp-2">{map.title}</h3>
+        </Link>
         <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
           {map.scale && <span>1 : {map.scale.toLocaleString()}</span>}
           {map.equidistance && <span>{map.equidistance} m</span>}

--- a/src/components/maps/MapStatusPoller.tsx
+++ b/src/components/maps/MapStatusPoller.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { getMapStatusAction } from '@/server/maps/actions'
+
+type ActiveStatus = 'pending' | 'processing'
+
+type MapStatusPollerProps = {
+  mapId: string
+  initialStatus: ActiveStatus
+}
+
+export const MapStatusPoller = ({ mapId, initialStatus }: MapStatusPollerProps) => {
+  const router = useRouter()
+  const [status, setStatus] = useState<string>(initialStatus)
+
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      const next = await getMapStatusAction(mapId)
+      if (!next) return
+      setStatus(next)
+      if (next === 'ready' || next === 'failed') {
+        clearInterval(interval)
+        router.refresh()
+      }
+    }, 3000)
+
+    return () => clearInterval(interval)
+  }, [mapId, router])
+
+  if (status === 'failed') {
+    return (
+      <p className="text-sm text-destructive">
+        Processing failed. Please try deleting and re-uploading the map.
+      </p>
+    )
+  }
+
+  return (
+    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+      <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+      {status === 'pending' ? 'Queued for processing…' : 'Processing your map…'}
+    </div>
+  )
+}

--- a/src/components/maps/MapViewer.tsx
+++ b/src/components/maps/MapViewer.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+type MapViewerProps = {
+  src: string
+  alt: string
+}
+
+export const MapViewer = ({ src, alt }: MapViewerProps) => {
+  return (
+    <div className="overflow-auto rounded-lg border border-border bg-muted/30">
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={src}
+        alt={alt}
+        className="max-w-full object-contain"
+        style={{ display: 'block' }}
+      />
+    </div>
+  )
+}

--- a/src/components/maps/ShareToggle.tsx
+++ b/src/components/maps/ShareToggle.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { toggleMapPublicAction } from '@/server/maps/actions'
+
+type ShareToggleProps = {
+  mapId: string
+  isPublic: boolean
+  shareUrl: string | null
+}
+
+export const ShareToggle = ({ mapId, isPublic: initialIsPublic, shareUrl: initialShareUrl }: ShareToggleProps) => {
+  const [isPublic, setIsPublic] = useState(initialIsPublic)
+  const [shareUrl, setShareUrl] = useState<string | null>(initialShareUrl)
+  const [error, setError] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+  const [isPending, startTransition] = useTransition()
+
+  const handleToggle = () => {
+    setError(null)
+    startTransition(async () => {
+      try {
+        const result = await toggleMapPublicAction(mapId)
+        setIsPublic(result.isPublic)
+        setShareUrl(result.shareUrl)
+      } catch {
+        setError('Failed to update sharing settings. Please try again.')
+      }
+    })
+  }
+
+  const handleCopy = () => {
+    if (!shareUrl) return
+    navigator.clipboard.writeText(shareUrl).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    })
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium">Public sharing</span>
+        <button
+          onClick={handleToggle}
+          disabled={isPending}
+          className="rounded-md bg-secondary px-3 py-1.5 text-xs font-medium text-secondary-foreground hover:opacity-90 disabled:opacity-50 transition-opacity"
+        >
+          {isPending ? 'Updating…' : isPublic ? 'Make private' : 'Make public'}
+        </button>
+      </div>
+
+      {error && <p className="text-xs text-destructive">{error}</p>}
+
+      {isPublic && shareUrl && (
+        <div className="flex gap-2">
+          <input
+            readOnly
+            value={shareUrl}
+            className="min-w-0 flex-1 rounded-md border border-input bg-muted px-3 py-1.5 text-xs text-muted-foreground"
+          />
+          <button
+            onClick={handleCopy}
+            className="rounded-md bg-secondary px-3 py-1.5 text-xs font-medium text-secondary-foreground hover:opacity-90 transition-opacity"
+          >
+            {copied ? 'Copied!' : 'Copy'}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/server/maps/actions.ts
+++ b/src/server/maps/actions.ts
@@ -1,8 +1,9 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
+import { headers } from 'next/headers'
 import { redirect } from 'next/navigation'
-import { eq } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import { z } from 'zod'
 import { auth } from '@/server/auth'
 import { db } from '@/server/db'
@@ -137,4 +138,55 @@ export const deleteMapAction = async (mapId: string): Promise<void> => {
   await db.delete(maps).where(eq(maps.id, mapId))
 
   revalidatePath('/maps')
+}
+
+export const getMapStatusAction = async (
+  mapId: string,
+): Promise<'pending' | 'processing' | 'ready' | 'failed' | null> => {
+  const session = await auth()
+  if (!session?.user?.id) return null
+
+  const row = await db
+    .select({ processingStatus: maps.processingStatus })
+    .from(maps)
+    .where(and(eq(maps.id, mapId), eq(maps.userId, session.user.id)))
+    .then((r) => r[0] ?? null)
+
+  return row?.processingStatus ?? null
+}
+
+export const toggleMapPublicAction = async (
+  mapId: string,
+): Promise<{ isPublic: boolean; shareUrl: string | null }> => {
+  const session = await auth()
+  if (!session?.user?.id) throw new Error('Not authenticated')
+
+  const map = await db
+    .select({ isPublic: maps.isPublic, shareToken: maps.shareToken })
+    .from(maps)
+    .where(and(eq(maps.id, mapId), eq(maps.userId, session.user.id)))
+    .then((r) => r[0] ?? null)
+
+  if (!map) throw new Error('Map not found')
+
+  const headersList = await headers()
+  const host = headersList.get('host') ?? 'localhost:3000'
+  const protocol = host.startsWith('localhost') ? 'http' : 'https'
+
+  if (map.isPublic) {
+    await db
+      .update(maps)
+      .set({ isPublic: false, shareToken: null })
+      .where(eq(maps.id, mapId))
+    revalidatePath('/maps')
+    return { isPublic: false, shareUrl: null }
+  } else {
+    const shareToken = crypto.randomUUID()
+    await db
+      .update(maps)
+      .set({ isPublic: true, shareToken })
+      .where(eq(maps.id, mapId))
+    revalidatePath('/maps')
+    return { isPublic: true, shareUrl: `${protocol}://${host}/share/${shareToken}` }
+  }
 }


### PR DESCRIPTION
## Summary
- Adds `/maps/[id]` RSC that fetches map + georeference with a `leftJoin` and returns `notFound()` for unknown/unauthorized maps
- `MapViewer` — client component rendering the processed image in a scrollable container
- `MapStatusPoller` — client component polling `getMapStatusAction` every 3 s, calls `router.refresh()` when status reaches `ready`/`failed`
- `ShareToggle` — client component calling `toggleMapPublicAction` via `useTransition`; shows share URL with copy button when public
- Two new server actions: `getMapStatusAction` (ownership-checked status fetch) and `toggleMapPublicAction` (generates/clears share token + URL)
- `MapCard` title now links to the detail page

## Test plan
- [ ] `pnpm typecheck` — zero errors ✅
- [ ] `pnpm lint` — zero errors ✅
- [ ] `pnpm test` — 9/9 passing ✅
- [ ] Upload a map, click its card title, verify detail page renders metadata
- [ ] Verify poller spins while `pending`/`processing` and refreshes on `ready`
- [ ] Toggle map public, confirm share URL appears; toggle back, confirm URL disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)