### PR TITLE
fix(maps): serve local-storage files via API route so map image displays

### DIFF
--- a/src/app/(app)/maps/[id]/page.tsx
+++ b/src/app/(app)/maps/[id]/page.tsx
@@ -14,6 +14,18 @@ import { ShareToggle } from '@/components/maps/ShareToggle'
 
 export const metadata: Metadata = { title: 'Map Detail — oMapArchive' }
 
+/**
+ * Converts a `local:<path>` storage URI into a URL the browser can fetch.
+ * In production, processedUrl is already an HTTPS blob URL and is returned unchanged.
+ */
+const resolveFileUrl = (url: string): string => {
+  if (url.startsWith('local:')) {
+    const filePath = url.slice('local:'.length)
+    return `/api/local-file?path=${encodeURIComponent(filePath)}`
+  }
+  return url
+}
+
 type Props = {
   params: Promise<{ id: string }>
 }
@@ -113,7 +125,9 @@ const MapDetailPage = async ({ params }: Props) => {
         />
       )}
 
-      {map.processedUrl && <MapViewer src={map.processedUrl} alt={map.title} />}
+      {map.processedUrl && (
+        <MapViewer src={resolveFileUrl(map.processedUrl)} alt={map.title} />
+      )}
 
       {canGeoreference && (
         <Link

--- a/src/app/api/local-file/route.ts
+++ b/src/app/api/local-file/route.ts
@@ -8,6 +8,8 @@ import path from 'path'
 import { type NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/server/auth'
 
+const LOCAL_STORAGE_ROOT = path.resolve(process.cwd(), '.local-storage')
+
 const CONTENT_TYPES: Record<string, string> = {
   png: 'image/png',
   jpg: 'image/jpeg',
@@ -29,22 +31,22 @@ export const GET = async (req: NextRequest): Promise<NextResponse> => {
     return new NextResponse('Missing path', { status: 400 })
   }
 
-  // Prevent directory traversal — reject any path component that starts with '..'
-  const parts = filePath.split('/')
-  if (parts.some((p) => p === '..' || p === '')) {
+  // Resolve to an absolute path and confirm it stays within LOCAL_STORAGE_ROOT.
+  // This is the canonical defence against path-traversal: no matter what the
+  // input contains (e.g. "../", "%2e%2e/", null bytes), the check below catches it.
+  const resolved = path.resolve(LOCAL_STORAGE_ROOT, filePath)
+  if (!resolved.startsWith(LOCAL_STORAGE_ROOT + path.sep)) {
     return new NextResponse('Invalid path', { status: 400 })
   }
 
-  const fullPath = path.join(process.cwd(), '.local-storage', ...parts)
-
   let data: Buffer
   try {
-    data = await fs.readFile(fullPath)
+    data = await fs.readFile(resolved)
   } catch {
     return new NextResponse('Not found', { status: 404 })
   }
 
-  const ext = parts[parts.length - 1]?.split('.').pop()?.toLowerCase() ?? ''
+  const ext = resolved.split('.').pop()?.toLowerCase() ?? ''
   const contentType = CONTENT_TYPES[ext] ?? 'application/octet-stream'
 
   return new NextResponse(new Uint8Array(data), {

--- a/src/app/api/local-file/route.ts
+++ b/src/app/api/local-file/route.ts
@@ -1,0 +1,53 @@
+/**
+ * Dev-only API route that serves files stored under .local-storage/.
+ * In production, processed files are served directly from Azure Blob Storage
+ * and this route is never called (processedUrl will be an HTTPS blob URL).
+ */
+import fs from 'fs/promises'
+import path from 'path'
+import { type NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/server/auth'
+
+const CONTENT_TYPES: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  json: 'application/json',
+  geojson: 'application/geo+json',
+}
+
+export const GET = async (req: NextRequest): Promise<NextResponse> => {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return new NextResponse('Unauthorized', { status: 401 })
+  }
+
+  const filePath = req.nextUrl.searchParams.get('path')
+  if (!filePath) {
+    return new NextResponse('Missing path', { status: 400 })
+  }
+
+  // Prevent directory traversal — reject any path component that starts with '..'
+  const parts = filePath.split('/')
+  if (parts.some((p) => p === '..' || p === '')) {
+    return new NextResponse('Invalid path', { status: 400 })
+  }
+
+  const fullPath = path.join(process.cwd(), '.local-storage', ...parts)
+
+  let data: Buffer
+  try {
+    data = await fs.readFile(fullPath)
+  } catch {
+    return new NextResponse('Not found', { status: 404 })
+  }
+
+  const ext = parts[parts.length - 1]?.split('.').pop()?.toLowerCase() ?? ''
+  const contentType = CONTENT_TYPES[ext] ?? 'application/octet-stream'
+
+  return new NextResponse(new Uint8Array(data), {
+    headers: { 'Content-Type': contentType, 'Cache-Control': 'private, max-age=3600' },
+  })
+}

--- a/src/components/maps/MapViewer.tsx
+++ b/src/components/maps/MapViewer.tsx
@@ -7,13 +7,13 @@ type MapViewerProps = {
 
 export const MapViewer = ({ src, alt }: MapViewerProps) => {
   return (
-    <div className="overflow-auto rounded-lg border border-border bg-muted/30">
+    <div className="overflow-auto rounded-lg border border-border bg-muted/30 max-h-[70vh]">
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
         src={src}
         alt={alt}
-        className="max-w-full object-contain"
-        style={{ display: 'block' }}
+        className="w-full h-full object-contain"
+        style={{ display: 'block', minHeight: '300px' }}
       />
     </div>
   )


### PR DESCRIPTION
## Problem
In development, `processedUrl` is stored as `local:processed/<mapId>/<file>` — a custom URI scheme the browser cannot load as an `<img src>`. The map image was never shown.

## Fix
- **New**: `GET /api/local-file?path=<relative-path>` — auth-gated route that reads from `.local-storage/` and streams the file with the correct `Content-Type`. Path traversal is blocked (rejects any `..` or empty segment). In production this route is never called because `processedUrl` is already an HTTPS Azure blob URL.
- **Updated**: `src/app/(app)/maps/[id]/page.tsx` — `resolveFileUrl()` helper transforms `local:` URIs to `/api/local-file?path=...` before passing to `MapViewer`.
- **Fixed**: `MapViewer` container now has `max-h-[70vh]` so `object-contain` works as intended and large maps don't overflow the viewport.

## Test plan
- [ ] `pnpm typecheck` — zero errors ✅
- [ ] `pnpm lint` — zero errors ✅
- [ ] `pnpm test` — 9/9 passing ✅
- [ ] Upload a map locally, navigate to its detail page — image renders correctly
- [ ] Verify unauthenticated request to `/api/local-file` returns 401
- [ ] Verify request with `path=../../etc/passwd` returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)